### PR TITLE
Install libgmp-dev by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     ca-certificates \
     "clang-$CLANG_VERSION" \
     curl \
+    libgmp-dev \
     libnuma-dev \
     "llvm-$CLANG_VERSION-dev" \
     make \


### PR DESCRIPTION
It's hard to do anything productive without this. 