### PR TITLE
Upgrade to GHC 9.2.2

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -19,7 +19,7 @@ jobs:
         ghc:
           - 8.10.7
           - 9.0.2
-          - 9.2.1
+          - 9.2.2
     runs-on: ubuntu-latest
     name: Docker with GHC ${{ matrix.ghc }}
     steps:


### PR DESCRIPTION
https://www.haskell.org/ghc/blog/20220305-ghc-9.2.2-released.html