### PR TITLE
Miscellaneous updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,6 @@ VOLUME "/home/$USER_NAME/.stack"
 ARG HLS_VERSION=1.7.0.0
 COPY run/install-hls.sh /tmp
 RUN /tmp/install-hls.sh
+VOLUME "/home/$USER_NAME/.cache"
 
 CMD [ "ghci" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ ARG USER_NAME=haskell
 COPY run/create-user.sh /tmp
 RUN /tmp/create-user.sh
 
-WORKDIR "/home/$USER_NAME"
 USER "$USER_NAME"
+WORKDIR "/home/$USER_NAME"
 ENV PATH="/home/$USER_NAME/.local/bin:/home/$USER_NAME/.cabal/bin:/home/$USER_NAME/.ghcup/bin:$PATH"
 
 ARG GHCUP_VERSION=0.1.17.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,11 @@ COPY run/install-ghc.sh /tmp
 RUN /tmp/install-ghc.sh
 
 ARG CABAL_VERSION=3.6.2.0
+ARG CABAL_STORE=/cabal-store
 COPY run/install-cabal.sh /tmp
 RUN /tmp/install-cabal.sh
 VOLUME "/home/$USER_NAME/.cabal"
+VOLUME "$CABAL_STORE"
 
 ARG STACK_VERSION=2.7.5
 COPY run/install-stack.sh /tmp

--- a/run/install-cabal.sh
+++ b/run/install-cabal.sh
@@ -3,5 +3,9 @@ set -o errexit -o xtrace
 
 ghcup install cabal "$CABAL_VERSION" --set
 cabal --version
-cabal user-config init
 mkdir --parents ~/.cabal/bin
+
+sudo mkdir "$CABAL_STORE"
+sudo chmod g+w "$CABAL_STORE"
+sudo chgrp sudo "$CABAL_STORE"
+cabal user-config init --augment "store-dir: $CABAL_STORE"

--- a/run/install-hls.sh
+++ b/run/install-hls.sh
@@ -3,3 +3,4 @@ set -o errexit -o xtrace
 
 ghcup install hls "$HLS_VERSION" --set
 haskell-language-server-wrapper --version
+mkdir --parents ~/.cache


### PR DESCRIPTION
- Switched back to a separate Cabal store. By default this is at `/cabal-store`.
- Created a volume for the HLS cache at `~/.cache`, owned by the user.